### PR TITLE
Simplify Server for nginx config

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,31 +4,9 @@ const http = require('http');
 const https = require('https');
 const fs = require('fs');
 const app = express();
-const HTTP_PORT = process.env.PORT || 3000;
-const HTTPS_PORT = process.env.PORT || 3001;
+const PORT = process.env.PORT || 3000;
 
 const clientBuild = path.join(__dirname, "..", "chester", "build");
-
-const privateKey = fs.readFileSync(path.join(__dirname, "..", "certs", "privatekey.pem"), "utf8");
-const certificate = fs.readFileSync(path.join(__dirname, "..", "certs", "certificate.pem"), "utf8");
-const ca = fs.readFileSync(path.join(__dirname, "..", "certs", "csr.pem"), "utf8");
-
-const credentials = {
-  key: privateKey,
-  cert: certificate,
-  ca: ca
-}
-
-const httpServer = http.createServer(app);
-const httpsServer = https.createServer(credentials, app);
-
-app.use((req, res, next) => {
-  if (req.secure || req.headers["x-forwarded-proto"] === "https") {
-    next();
-  } else {
-    res.redirect("https://" + req.headers.host + req.url);
-  }
-});
 
 app.use(express.static(clientBuild));
 
@@ -40,10 +18,6 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(clientBuild, "index.html"));
 });
 
-httpServer.listen(HTTP_PORT, () => {
-  console.log(`Portfolio listening on ${HTTP_PORT} ---> mapped to 80`);
-});
-
-httpsServer.listen(HTTPS_PORT, () => {
-  console.log(`Portfolio listening on port ${HTTPS_PORT} ---> mapped to 443`);
+app.listen(PORT, () => {
+  console.log(`Portfolio listening on ${PORT} ---> mapped to 3000`);
 });


### PR DESCRIPTION
Remove certs and http/https server so we can utilize a reverse proxy to do this more elegantly